### PR TITLE
Refactor: Implement Blueprint-Based Scene System and Relativistic Portal Rendering

### DIFF
--- a/src/demo_scene.rs
+++ b/src/demo_scene.rs
@@ -1,109 +1,107 @@
 // src/demo_scene.rs
 
-use crate::engine_lib::scene_types::{Scene, Hull, SceneSide, Point3};
+use std::collections::HashMap;
+use crate::engine_lib::scene_types::{
+    Scene, HullBlueprint, BlueprintSide, HullInstance,
+    Point3, Mat4, HandlerConfig, SideHandlerTypeId,
+    PortalConnectionInfo, PortalId,
+    BlueprintId, InstanceId, SideIndex,
+};
+
+const CUBOID_BLUEPRINT_ID: BlueprintId = 0;
+const ROOM1_INSTANCE_ID: InstanceId = 0;
+const ROOM2_INSTANCE_ID: InstanceId = 1;
+
+pub const PORTAL_ID_FRONT: PortalId = 0;
+pub const PORTAL_ID_BACK: PortalId = 1;
+pub const PORTAL_ID_LEFT: PortalId = 2;
+pub const PORTAL_ID_RIGHT: PortalId = 3;
+pub const PORTAL_ID_TOP: PortalId = 4;
+pub const PORTAL_ID_BOTTOM: PortalId = 5;
+
+const CEILING_COLOR_CONF: HandlerConfig = HandlerConfig::StandardWall { color: [1.0, 0.0, 0.0, 1.0], texture_id: None };
+const FLOOR_COLOR_CONF: HandlerConfig = HandlerConfig::StandardWall { color: [0.0, 1.0, 0.0, 1.0], texture_id: None };
+const LEFT_WALL_COLOR_CONF: HandlerConfig = HandlerConfig::StandardWall { color: [1.0, 1.0, 1.0, 1.0], texture_id: None };
+const RIGHT_WALL_COLOR_CONF: HandlerConfig = HandlerConfig::StandardWall { color: [0.5, 0.5, 0.5, 1.0], texture_id: None };
+const FRONT_WALL_COLOR_BLUE_CONF: HandlerConfig = HandlerConfig::StandardWall { color: [0.3, 0.3, 0.8, 1.0], texture_id: None }; 
+const BACK_WALL_YELLOW_CONF: HandlerConfig = HandlerConfig::StandardWall { color: [0.8, 0.8, 0.3, 1.0], texture_id: None }; 
+const ORANGE_WALL_CONF: HandlerConfig = HandlerConfig::StandardWall {color: [0.9, 0.5, 0.2, 1.0], texture_id: None }; 
+
+fn create_cuboid_room_blueprint() -> HullBlueprint {
+    let half_size = 1.5; 
+    let vertices = vec![
+        Point3::new(-half_size, -half_size, -half_size), Point3::new( half_size, -half_size, -half_size),
+        Point3::new( half_size,  half_size, -half_size), Point3::new(-half_size,  half_size, -half_size),
+        Point3::new(-half_size, -half_size,  half_size), Point3::new( half_size, -half_size,  half_size),
+        Point3::new( half_size,  half_size,  half_size), Point3::new(-half_size,  half_size,  half_size),
+    ];
+    let sides = vec![
+        BlueprintSide { vertex_indices: vec![4,5,6,7], local_normal: Point3::new(0.0,0.0,-1.0), handler_type:SideHandlerTypeId::StandardWall, default_handler_config:FRONT_WALL_COLOR_BLUE_CONF.clone(), local_portal_id: Some(PORTAL_ID_FRONT) },
+        BlueprintSide { vertex_indices: vec![1,0,3,2], local_normal: Point3::new(0.0,0.0,1.0), handler_type:SideHandlerTypeId::StandardWall, default_handler_config:BACK_WALL_YELLOW_CONF.clone(), local_portal_id: Some(PORTAL_ID_BACK) },
+        BlueprintSide { vertex_indices: vec![0,4,7,3], local_normal: Point3::new(1.0,0.0,0.0), handler_type:SideHandlerTypeId::StandardWall, default_handler_config:LEFT_WALL_COLOR_CONF.clone(), local_portal_id: Some(PORTAL_ID_LEFT) },
+        BlueprintSide { vertex_indices: vec![5,1,2,6], local_normal: Point3::new(-1.0,0.0,0.0), handler_type:SideHandlerTypeId::StandardWall, default_handler_config:RIGHT_WALL_COLOR_CONF.clone(), local_portal_id: Some(PORTAL_ID_RIGHT) },
+        BlueprintSide { vertex_indices: vec![7,6,2,3], local_normal: Point3::new(0.0,-1.0,0.0), handler_type:SideHandlerTypeId::StandardWall, default_handler_config:CEILING_COLOR_CONF.clone(), local_portal_id: Some(PORTAL_ID_TOP) },
+        BlueprintSide { vertex_indices: vec![0,1,5,4], local_normal: Point3::new(0.0,1.0,0.0), handler_type:SideHandlerTypeId::StandardWall, default_handler_config:FLOOR_COLOR_CONF.clone(), local_portal_id: Some(PORTAL_ID_BOTTOM) },
+    ];
+    HullBlueprint { id: CUBOID_BLUEPRINT_ID, name: "CuboidRoomBlueprint_InwardNormals".to_string(), local_vertices: vertices, sides }
+}
 
 pub fn create_mvp_scene() -> Scene {
-    let mut hulls = Vec::new();
+    let mut blueprints = HashMap::new();
+    let cuboid_bp = create_cuboid_room_blueprint();
+    blueprints.insert(cuboid_bp.id, cuboid_bp);
 
-    const CEILING_COLOR: [f32; 4] = [1.0, 0.0, 0.0, 1.0]; // Red
-    const FLOOR_COLOR:   [f32; 4] = [0.0, 1.0, 0.0, 1.0]; // Green
-    const LEFT_WALL_COLOR: [f32; 4] = [1.0, 1.0, 1.0, 1.0]; // White
-    const RIGHT_WALL_COLOR: [f32; 4] = [0.5, 0.5, 0.5, 1.0]; // Dark Gray (using 0.5 to distinguish from other grays)
-    const ALPHA: f32 = 1.0;
+    let mut instances = HashMap::new();
 
-    let room1_center = Point3::new(0.0, 0.0, -3.0);
-    let room1_half_size = 1.5;
-    let r1_v = [ 
-        Point3::new(room1_center.x - room1_half_size, room1_center.y - room1_half_size, room1_center.z - room1_half_size),
-        Point3::new(room1_center.x + room1_half_size, room1_center.y - room1_half_size, room1_center.z - room1_half_size),
-        Point3::new(room1_center.x + room1_half_size, room1_center.y + room1_half_size, room1_center.z - room1_half_size),
-        Point3::new(room1_center.x - room1_half_size, room1_center.y + room1_half_size, room1_center.z - room1_half_size),
-        Point3::new(room1_center.x - room1_half_size, room1_center.y - room1_half_size, room1_center.z + room1_half_size),
-        Point3::new(room1_center.x + room1_half_size, room1_center.y - room1_half_size, room1_center.z + room1_half_size),
-        Point3::new(room1_center.x + room1_half_size, room1_center.y + room1_half_size, room1_center.z + room1_half_size),
-        Point3::new(room1_center.x - room1_half_size, room1_center.y + room1_half_size, room1_center.z + room1_half_size),
-    ];
+    let mut room1_portal_connections = HashMap::new();
+    let mut room1_side_configs = HashMap::new();
+    room1_side_configs.insert(0 as SideIndex, HandlerConfig::StandardPortal { 
+        target_instance_id: ROOM2_INSTANCE_ID, target_portal_id: PORTAL_ID_BACK, 
+    });
+    room1_portal_connections.insert(PORTAL_ID_FRONT, PortalConnectionInfo {
+        target_instance_id: ROOM2_INSTANCE_ID, target_portal_id: PORTAL_ID_BACK,
+    });
+    let room1 = HullInstance {
+        id: ROOM1_INSTANCE_ID, name: "Room1".to_string(), blueprint_id: CUBOID_BLUEPRINT_ID,
+        initial_transform: Some(Mat4::from_translation(Point3::new(0.0, 0.0, 0.0))),
+        portal_connections: room1_portal_connections, 
+        instance_side_handler_configs: room1_side_configs,
+    };
+    instances.insert(room1.id, room1);
+
+    // Room 2 connects back to Room 1
+    let mut room2_portal_connections: HashMap<PortalId, PortalConnectionInfo> = HashMap::new(); // Explicit type
+    let mut room2_side_configs = HashMap::new();
     
-    let room1_sides = vec![
-        SceneSide { // Portal
-            vertices_3d: vec![r1_v[4], r1_v[5], r1_v[6], r1_v[7]], 
-            normal: Point3::new(0.0, 0.0, 1.0), is_portal: true, connected_hull_id: Some(1), 
-            color: [0.0, 0.0, 0.0, 0.0],
-        },
-        SceneSide { // Left Wall (-X side of room)
-            vertices_3d: vec![r1_v[0], r1_v[4], r1_v[7], r1_v[3]], 
-            normal: Point3::new(-1.0, 0.0, 0.0), is_portal: false, connected_hull_id: None, 
-            color: LEFT_WALL_COLOR,
-        },
-        SceneSide { // Right Wall (+X side of room)
-            vertices_3d: vec![r1_v[5], r1_v[1], r1_v[2], r1_v[6]], 
-            normal: Point3::new(1.0, 0.0, 0.0), is_portal: false, connected_hull_id: None, 
-            color: RIGHT_WALL_COLOR,
-        },
-        SceneSide { // Bottom Wall (Floor)
-            vertices_3d: vec![r1_v[4], r1_v[0], r1_v[1], r1_v[5]], 
-            normal: Point3::new(0.0, -1.0, 0.0), is_portal: false, connected_hull_id: None, 
-            color: FLOOR_COLOR,
-        },
-        SceneSide { // Top Wall (Ceiling)
-            vertices_3d: vec![r1_v[3], r1_v[7], r1_v[6], r1_v[2]], 
-            normal: Point3::new(0.0, 1.0, 0.0), is_portal: false, connected_hull_id: None, 
-            color: CEILING_COLOR,
-        },
-        SceneSide { // Back Wall
-            vertices_3d: vec![r1_v[1],r1_v[0],r1_v[3],r1_v[2]], 
-            normal: Point3::new(0.0, 0.0, -1.0), is_portal: false, connected_hull_id: None, 
-            color: [0.3, 0.3, 0.3, ALPHA], // Darker Grey for this back wall
-        },
-    ];
-    hulls.push(Hull { id: 0, sides: room1_sides });
+    room2_side_configs.insert(1 as SideIndex, HandlerConfig::StandardPortal { 
+        target_instance_id: ROOM1_INSTANCE_ID,
+        target_portal_id: PORTAL_ID_FRONT, 
+    });
+    room2_portal_connections.insert(PORTAL_ID_BACK, PortalConnectionInfo { // Add connection info
+        target_instance_id: ROOM1_INSTANCE_ID,
+        target_portal_id: PORTAL_ID_FRONT,
+    });
+    room2_side_configs.insert(0 as SideIndex, ORANGE_WALL_CONF.clone()); 
 
-    let room2_center = Point3::new(0.0, 0.0, room1_center.z + room1_half_size * 2.0); 
-    let room2_half_size = 1.5;
-    let r2_v = [
-        Point3::new(room2_center.x - room2_half_size, room2_center.y - room2_half_size, room2_center.z - room2_half_size),
-        Point3::new(room2_center.x + room2_half_size, room2_center.y - room2_half_size, room2_center.z - room2_half_size),
-        Point3::new(room2_center.x + room2_half_size, room2_center.y + room2_half_size, room2_center.z - room2_half_size),
-        Point3::new(room2_center.x - room2_half_size, room2_center.y + room2_half_size, room2_center.z - room2_half_size),
-        Point3::new(room2_center.x - room2_half_size, room2_center.y - room2_half_size, room2_center.z + room2_half_size),
-        Point3::new(room2_center.x + room2_half_size, room2_center.y - room2_half_size, room2_center.z + room2_half_size),
-        Point3::new(room2_center.x + room2_half_size, room2_center.y + room2_half_size, room2_center.z + room2_half_size),
-        Point3::new(room2_center.x - room2_half_size, room2_center.y + room2_half_size, room2_center.z + room2_half_size),
-    ];
+    let room2 = HullInstance {
+        id: ROOM2_INSTANCE_ID, name: "Room2".to_string(), blueprint_id: CUBOID_BLUEPRINT_ID,
+        initial_transform: None, 
+        portal_connections: room2_portal_connections, 
+        instance_side_handler_configs: room2_side_configs,
+    };
+    instances.insert(room2.id, room2);
 
-    let room2_sides = vec![
-        SceneSide { // Portal Wall
-            vertices_3d: vec![r2_v[3], r2_v[2], r2_v[1], r2_v[0]],
-            normal: Point3::new(0.0, 0.0, -1.0), is_portal: true, connected_hull_id: Some(0),
-            color: [0.0, 0.0, 0.0, 0.0],
-        },
-        SceneSide { // Back Wall
-            vertices_3d: vec![r2_v[5], r2_v[4], r2_v[7], r2_v[6]],
-            normal: Point3::new(0.0, 0.0, 1.0), is_portal: false, connected_hull_id: None, 
-            color: [0.9, 0.5, 0.2, ALPHA], // Orange
-        },
-        SceneSide { // Left Wall (-X side of room)
-            vertices_3d: vec![r2_v[0], r2_v[4], r2_v[7], r2_v[3]],
-            normal: Point3::new(-1.0, 0.0, 0.0), is_portal: false, connected_hull_id: None, 
-            color: LEFT_WALL_COLOR,
-        },
-        SceneSide { // Right Wall (+X side of room)
-            vertices_3d: vec![r2_v[5], r2_v[1], r2_v[2], r2_v[6]],
-            normal: Point3::new(1.0, 0.0, 0.0), is_portal: false, connected_hull_id: None, 
-            color: RIGHT_WALL_COLOR,
-        },
-         SceneSide { // Bottom Wall (Floor)
-            vertices_3d: vec![r2_v[4], r2_v[0], r2_v[1], r2_v[5]],
-            normal: Point3::new(0.0, -1.0, 0.0), is_portal: false, connected_hull_id: None, 
-            color: FLOOR_COLOR,
-        },
-        SceneSide { // Top Wall (Ceiling)
-            vertices_3d: vec![r2_v[3], r2_v[7], r2_v[6], r2_v[2]],
-            normal: Point3::new(0.0, 1.0, 0.0), is_portal: false, connected_hull_id: None, 
-            color: CEILING_COLOR,
-        },
-    ];
-    hulls.push(Hull { id: 1, sides: room2_sides });
+    let initial_camera_position_in_room1 = Point3::new(0.0, 0.0, -1.0); 
+    let initial_camera_yaw_rad = std::f32::consts::PI; 
+    let initial_camera_pitch_rad = 0.0f32.to_radians();
+    let rot_y = Mat4::from_rotation_y(initial_camera_yaw_rad);
+    let rot_x = Mat4::from_rotation_x(initial_camera_pitch_rad);
+    let initial_rotation = rot_y.multiply(&rot_x);
+    let initial_camera_transform = Mat4::from_translation(initial_camera_position_in_room1).multiply(&initial_rotation);
 
-    Scene { hulls }
+    Scene {
+        blueprints, instances,
+        active_camera_instance_id: ROOM1_INSTANCE_ID,
+        active_camera_local_transform: initial_camera_transform,
+    }
 }

--- a/src/engine_lib/camera.rs
+++ b/src/engine_lib/camera.rs
@@ -1,14 +1,10 @@
-// src/camera.rs
+// src/engine_lib/camera.rs
 
+use crate::engine_lib::scene_types::{Point3, Mat4};
 use crate::rendering_lib::geometry::Point2;
-use super::scene_types::Point3;
-
 
 #[derive(Debug)]
 pub struct Camera {
-    pub position: Point3,
-    pub yaw: f32,
-    pub pitch: f32,
     pub fov_y_rad: f32,
     pub znear: f32,
     pub zfar: f32,
@@ -16,75 +12,41 @@ pub struct Camera {
 
 impl Camera {
     pub fn new(
-        position: Point3,
-        yaw_deg: f32,
-        pitch_deg: f32,
         fov_y_deg: f32,
         znear: f32,
         zfar: f32,
     ) -> Self {
         Self {
-            position,
-            yaw: yaw_deg.to_radians(),
-            pitch: pitch_deg.to_radians(),
             fov_y_rad: fov_y_deg.to_radians(),
             znear,
             zfar,
         }
     }
 
-    pub fn transform_to_camera_space(&self, world_point: &Point3) -> Point3 {
-        let cos_pitch = self.pitch.cos();
-        let sin_pitch = self.pitch.sin();
-        let cos_yaw = self.yaw.cos();
-        let sin_yaw = self.yaw.sin();
-
-        let mut p_cam = world_point.sub(&self.position);
-
-        let x_rotated_yaw = p_cam.x * cos_yaw - p_cam.z * sin_yaw;
-        let z_rotated_yaw = p_cam.x * sin_yaw + p_cam.z * cos_yaw;
-        p_cam.x = x_rotated_yaw;
-        p_cam.z = z_rotated_yaw;
-
-        let y_rotated_pitch = p_cam.y * cos_pitch - p_cam.z * sin_pitch;
-        let z_rotated_pitch = p_cam.y * sin_pitch + p_cam.z * cos_pitch;
-        p_cam.y = y_rotated_pitch;
-        p_cam.z = z_rotated_pitch;
-
-        p_cam
+    // Constructs the view matrix that transforms points from the
+    // camera's host hull's blueprint space into the camera's view space.
+    // `camera_pose_in_host_hull` is the transform from CamLocal -> HostHullBlueprint.
+    // The view matrix is its inverse: HostHullBlueprint -> CamLocal.
+    pub fn get_view_matrix_from_host_hull(&self, camera_pose_in_host_hull: &Mat4) -> Mat4 {
+        camera_pose_in_host_hull.inverse()
     }
 
-    pub fn project_camera_space_to_screen(
+    // Projects points that are ALREADY in camera view space to screen space.
+    pub fn project_camera_space_to_screen_direct(
         &self,
-        p_cam: &Point3,
+        p_cam: &Point3, // Point in camera view space
         screen_width: f32,
         screen_height: f32,
     ) -> Option<Point2> {
-        // Near plane check (camera looks down its local -Z axis, points in front have p_cam.z < 0)
-        // Cull if p_cam.z is *behind or on* the near plane from the eye's perspective.
-        // We want to allow points ON the near plane if our clipper put them there.
-        // A point is "behind" if its z value in camera space is > -self.znear
-        // (i.e., less negative than -self.znear, or positive).
-
-        if p_cam.z > -self.znear {  // Cull if z is greater (less negative / more positive) than -znear
+        if p_cam.z > -self.znear + 1e-6 { // Cull if z is greater (less negative / more positive) than -znear
             return None;
         }
-        // Optional: Add a very small epsilon if floating point issues persist with exact equality:
-        // if p_cam.z > -self.znear + 1e-6 { return None; }
-
-
         if p_cam.z < -self.zfar { // Far plane check
             return None;
         }
-        
-        // Avoid division by zero or by a number very close to zero if p_cam.z is -self.znear
-        // and self.znear is extremely small, or if -p_cam.z itself is near zero.
-        // The check `p_cam.z > -self.znear` should already prevent `p_cam.z` from being positive or zero.
-        // It ensures `-p_cam.z` is at least `self.znear` (which is 0.1).
-        if -p_cam.z < 1e-6 { // Effectively checks if p_cam.z is too close to 0 from negative side
+        if -p_cam.z < 1e-6 { // Avoid division by zero if p_cam.z is too close to 0 from negative side
             return None;
         }
-
 
         let aspect_ratio = screen_width / screen_height;
         let focal_length_y = 1.0 / (self.fov_y_rad / 2.0).tan();
@@ -94,18 +56,8 @@ impl Camera {
         let ndc_y = (p_cam.y * focal_length_y) / -p_cam.z;
 
         let screen_x = (ndc_x + 1.0) * 0.5 * screen_width;
-        let screen_y = (1.0 - ndc_y) * 0.5 * screen_height;
+        let screen_y = (1.0 - ndc_y) * 0.5 * screen_height; // Invert Y for screen space
 
         Some(Point2::new(screen_x, screen_y))
-    }
-
-    pub fn project_to_screen(
-        &self,
-        world_point: &Point3,
-        screen_width: f32,
-        screen_height: f32,
-    ) -> Option<Point2> {
-        let p_cam = self.transform_to_camera_space(world_point);
-        self.project_camera_space_to_screen(&p_cam, screen_width, screen_height)
     }
 }

--- a/src/engine_lib/mod.rs
+++ b/src/engine_lib/mod.rs
@@ -1,8 +1,16 @@
-// engine_lib/src/lib.rs
-pub mod scene_types; // Renamed from scene.rs to avoid confusion, contains only types
-pub mod camera;
-pub mod controller; // New file for input handling
+// src/engine_lib/mod.rs
 
-pub use scene_types::{Point3, SceneSide, Hull, Scene, TraversalState};
+pub mod scene_types;
+pub mod camera;
+pub mod controller;
+pub mod side_handler; // Added new module
+
+// Re-export key types from the new structure
+pub use scene_types::{
+    Point3, Mat4, Scene, HullBlueprint, HullInstance, BlueprintSide,
+    HandlerConfig, SideHandlerTypeId, PortalConnectionInfo, TraversalState,
+    InstanceId, BlueprintId, PortalId, SideIndex,
+};
 pub use camera::Camera;
-pub use controller::CameraController; // Or whatever the main struct in controller.rs is
+pub use controller::CameraController;
+pub use side_handler::{SideHandler, StandardWallHandler, StandardPortalHandler, HandlerContext, MAX_PORTAL_RECURSION_DEPTH};

--- a/src/engine_lib/scene_types.rs
+++ b/src/engine_lib/scene_types.rs
@@ -2,6 +2,138 @@
 
 use crate::rendering_lib::geometry::ConvexPolygon;
 
+// Type aliases for IDs
+pub type BlueprintId = u32;
+pub type InstanceId = u32;
+pub type PortalId = u32;
+pub type SideIndex = usize;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Mat4 {
+    pub data: [[f32; 4]; 4], // Row-major: data[row][column]
+}
+
+impl Mat4 {
+    pub fn identity() -> Self {
+        Self {
+            data: [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ],
+        }
+    }
+
+    pub fn multiply(&self, other: &Mat4) -> Mat4 {
+        let mut result = [[0.0f32; 4]; 4];
+        for i in 0..4 {
+            for j in 0..4 {
+                for k in 0..4 {
+                    result[i][j] += self.data[i][k] * other.data[k][j];
+                }
+            }
+        }
+        Mat4 { data: result }
+    }
+
+    pub fn transform_point(&self, point: &Point3) -> Point3 {
+        let x = self.data[0][0] * point.x + self.data[0][1] * point.y + self.data[0][2] * point.z + self.data[0][3];
+        let y = self.data[1][0] * point.x + self.data[1][1] * point.y + self.data[1][2] * point.z + self.data[1][3];
+        let z = self.data[2][0] * point.x + self.data[2][1] * point.y + self.data[2][2] * point.z + self.data[2][3];
+        let w = self.data[3][0] * point.x + self.data[3][1] * point.y + self.data[3][2] * point.z + self.data[3][3];
+
+        if w.abs() < 1e-6 { // Avoid division by zero or very small w
+            Point3::new(x, y, z) 
+        } else {
+            Point3::new(x / w, y / w, z / w)
+        }
+    }
+    
+    pub fn from_translation(translation: Point3) -> Self {
+        Self {
+            data: [
+                [1.0, 0.0, 0.0, translation.x],
+                [0.0, 1.0, 0.0, translation.y],
+                [0.0, 0.0, 1.0, translation.z],
+                [0.0, 0.0, 0.0, 1.0],
+            ],
+        }
+    }
+
+    pub fn from_rotation_y(angle_rad: f32) -> Self {
+        let cos_a = angle_rad.cos();
+        let sin_a = angle_rad.sin();
+        Self {
+            data: [
+                [cos_a,  0.0, sin_a, 0.0],
+                [0.0,    1.0, 0.0,   0.0],
+                [-sin_a, 0.0, cos_a, 0.0],
+                [0.0,    0.0, 0.0,   1.0],
+            ],
+        }
+    }
+    
+    pub fn from_rotation_x(angle_rad: f32) -> Self {
+        let cos_a = angle_rad.cos();
+        let sin_a = angle_rad.sin();
+        Self {
+            data: [
+                [1.0, 0.0,   0.0,    0.0],
+                [0.0, cos_a, -sin_a, 0.0],
+                [0.0, sin_a, cos_a,  0.0],
+                [0.0, 0.0,   0.0,    1.0],
+            ],
+        }
+    }
+    
+    pub fn from_rotation_z(angle_rad: f32) -> Self {
+        let cos_a = angle_rad.cos();
+        let sin_a = angle_rad.sin();
+        Self {
+            data: [
+                [cos_a, -sin_a, 0.0, 0.0],
+                [sin_a, cos_a,  0.0, 0.0],
+                [0.0,   0.0,    1.0, 0.0],
+                [0.0,   0.0,    0.0, 1.0],
+            ],
+        }
+    }
+
+    pub fn inverse(&self) -> Mat4 {
+        // WARNING: This is a simplified inverse for orthonormal rotation + translation.
+        // (Assumes M = T * R, so M_inv = R_inv * T_inv)
+        let mut rot_inv_t = Mat4::identity();
+        // Transpose the rotation part (upper 3x3 of self, which is R)
+        for r_idx in 0..3 {
+            for c_idx in 0..3 {
+                rot_inv_t.data[r_idx][c_idx] = self.data[c_idx][r_idx];
+            }
+        }
+        // Extract translation part T_vec from self
+        let trans_vec = Point3::new(self.data[0][3], self.data[1][3], self.data[2][3]);
+        // Calculate -R_inv * T_vec for the translation part of the final inverse matrix
+        let inv_translation_component = rot_inv_t.transform_normal(&Point3::new(-trans_vec.x, -trans_vec.y, -trans_vec.z));
+        
+        rot_inv_t.data[0][3] = inv_translation_component.x;
+        rot_inv_t.data[1][3] = inv_translation_component.y;
+        rot_inv_t.data[2][3] = inv_translation_component.z;
+        
+        rot_inv_t
+    }
+
+    // Transforms a normal vector (direction only, no translation).
+    // Assumes M's upper 3x3 is the rotation/scaling part.
+    // For non-uniform scaling, inverse transpose of upper 3x3 is needed.
+    // This simplified version is fine for rotation and uniform scaling.
+    pub fn transform_normal(&self, normal: &Point3) -> Point3 {
+        let x = self.data[0][0] * normal.x + self.data[0][1] * normal.y + self.data[0][2] * normal.z;
+        let y = self.data[1][0] * normal.x + self.data[1][1] * normal.y + self.data[1][2] * normal.z;
+        let z = self.data[2][0] * normal.x + self.data[2][1] * normal.y + self.data[2][2] * normal.z;
+        Point3::new(x, y, z).normalize() 
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Point3 {
     pub x: f32,
@@ -23,44 +155,93 @@ impl Point3 {
     pub fn length(&self) -> f32 { (self.x * self.x + self.y * self.y + self.z * self.z).sqrt() }
     pub fn normalize(&self) -> Point3 {
         let l = self.length();
-        if l == 0.0 { Point3::new(0.0, 0.0, 0.0) } 
+        if l.abs() < 1e-6 { Point3::new(0.0, 0.0, 0.0) } // Avoid division by zero
         else { Point3::new(self.x / l, self.y / l, self.z / l) }
     }
     pub fn add(&self, other: &Point3) -> Point3 { Point3::new(self.x + other.x, self.y + other.y, self.z + other.z) }
     pub fn mul_scalar(&self, scalar: f32) -> Point3 { Point3::new(self.x * scalar, self.y * scalar, self.z * scalar) }
 }
 
-#[derive(Clone, Debug)]
-pub struct SceneSide {
-    pub vertices_3d: Vec<Point3>,
-    pub normal: Point3,
-    pub is_portal: bool,
-    pub connected_hull_id: Option<usize>,
-    pub color: [f32; 4],
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum SideHandlerTypeId {
+    StandardWall,
+    StandardPortal,
+    Mirror,
+    CameraDisplay,
+    NonEuclideanPortal,
+    TransparentWall,
 }
 
-impl SceneSide {
-    pub fn calculate_normal(vertices: &[Point3]) -> Point3 {
-        if vertices.len() < 3 { return Point3::new(0.0, 0.0, 1.0); }
-        let v0 = vertices[0]; let v1 = vertices[1]; let v2 = vertices[2];
-        let edge1 = v1.sub(&v0); let edge2 = v2.sub(&v0);
-        edge1.cross(&edge2).normalize()
+#[derive(Clone, Debug)]
+pub enum HandlerConfig {
+    StandardWall { color: [f32; 4], texture_id: Option<String> },
+    StandardPortal { target_instance_id: InstanceId, target_portal_id: PortalId },
+    Mirror { recursion_limit: u8, surface_reflectivity: f32 },
+    CameraDisplay { source_camera_id: String, refresh_rate: f32 },
+    NonEuclideanPortal { target_instance_id: InstanceId, target_portal_id: PortalId, transform_params: String },
+    TransparentWall { tint: [f32; 4], opacity: f32, ior: f32 },
+    None,
+}
+
+impl HandlerConfig {
+    pub fn get_intended_handler_type(&self) -> SideHandlerTypeId {
+        match self {
+            HandlerConfig::StandardWall { .. } => SideHandlerTypeId::StandardWall,
+            HandlerConfig::StandardPortal { .. } => SideHandlerTypeId::StandardPortal,
+            HandlerConfig::Mirror { .. } => SideHandlerTypeId::Mirror,
+            HandlerConfig::CameraDisplay { .. } => SideHandlerTypeId::CameraDisplay,
+            HandlerConfig::NonEuclideanPortal { .. } => SideHandlerTypeId::NonEuclideanPortal,
+            HandlerConfig::TransparentWall { .. } => SideHandlerTypeId::TransparentWall,
+            HandlerConfig::None => SideHandlerTypeId::StandardWall, 
+        }
     }
 }
 
 #[derive(Clone, Debug)]
-pub struct Hull {
-    pub id: usize,
-    pub sides: Vec<SceneSide>,
+pub struct BlueprintSide {
+    pub vertex_indices: Vec<usize>,
+    pub local_normal: Point3, // Points TOWARDS THE INTERIOR of the blueprint
+    pub handler_type: SideHandlerTypeId, 
+    pub default_handler_config: HandlerConfig,
+    pub local_portal_id: Option<PortalId>,
+}
+
+#[derive(Clone, Debug)]
+pub struct HullBlueprint {
+    pub id: BlueprintId,
+    pub name: String,
+    pub local_vertices: Vec<Point3>,
+    pub sides: Vec<BlueprintSide>,
+}
+
+#[derive(Clone, Debug)]
+pub struct PortalConnectionInfo {
+    pub target_instance_id: InstanceId,
+    pub target_portal_id: PortalId,
+}
+
+#[derive(Clone, Debug)]
+pub struct HullInstance {
+    pub id: InstanceId,
+    pub name: String,
+    pub blueprint_id: BlueprintId,
+    pub initial_transform: Option<Mat4>,
+    pub portal_connections: std::collections::HashMap<PortalId, PortalConnectionInfo>,
+    pub instance_side_handler_configs: std::collections::HashMap<SideIndex, HandlerConfig>,
 }
 
 #[derive(Debug)]
 pub struct Scene {
-    pub hulls: Vec<Hull>,
+    pub blueprints: std::collections::HashMap<BlueprintId, HullBlueprint>,
+    pub instances: std::collections::HashMap<InstanceId, HullInstance>,
+    pub active_camera_instance_id: InstanceId,
+    pub active_camera_local_transform: Mat4,
 }
 
 #[derive(Clone)]
 pub struct TraversalState {
-    pub hull_id: usize,
-    pub screen_space_clip_polygon: ConvexPolygon, // This type comes from geometry.rs
+    pub current_instance_id: InstanceId,
+    pub accumulated_transform: Mat4,
+    pub screen_space_clip_polygon: ConvexPolygon,
+    pub recursion_depth: u32,
 }

--- a/src/engine_lib/side_handler.rs
+++ b/src/engine_lib/side_handler.rs
@@ -1,0 +1,115 @@
+// src/engine_lib/side_handler.rs
+use std::collections::VecDeque;
+use crate::engine_lib::scene_types::{
+    Scene, Point3, Mat4, HandlerConfig,
+    HullInstance, BlueprintSide, TraversalState
+    // SideHandlerTypeId is inferred from HandlerConfig::get_intended_handler_type()
+    // HullBlueprint is accessed via scene.blueprints
+};
+use crate::engine_lib::camera::Camera;
+use crate::rendering_lib::geometry::ConvexPolygon;
+use crate::rendering_lib::vertex::Vertex;
+
+pub const MAX_PORTAL_RECURSION_DEPTH: u32 = 10;
+
+pub struct HandlerContext<'a> {
+    pub frame_vertices: &'a mut Vec<Vertex>,
+    pub frame_indices: &'a mut Vec<u16>,
+    pub scene: &'a Scene,
+    pub camera: &'a Camera,
+    pub current_instance: &'a HullInstance,
+    pub blueprint_side: &'a BlueprintSide,
+    pub side_config: &'a HandlerConfig,
+    pub transform_to_camera_host_hull: &'a Mat4,
+    pub camera_view_from_host_hull: &'a Mat4,
+    pub screen_width: f32,
+    pub screen_height: f32,
+    pub visible_screen_polygon: ConvexPolygon,
+    pub traversal_queue: &'a mut VecDeque<TraversalState>,
+    pub current_recursion_depth: u32,
+}
+
+pub trait SideHandler: Send + Sync {
+    fn process_render(&self, ctx: &mut HandlerContext);
+}
+
+pub struct StandardWallHandler;
+impl SideHandler for StandardWallHandler {
+    fn process_render(&self, ctx: &mut HandlerContext) {
+        let wall_color = match ctx.side_config {
+            HandlerConfig::StandardWall { color, .. } => *color,
+            _ => [0.7, 0.7, 0.7, 1.0], 
+        };
+        if ctx.visible_screen_polygon.count() >= 3 {
+            let start_vertex_index = ctx.frame_vertices.len() as u16;
+            for point in ctx.visible_screen_polygon.vertices() {
+                ctx.frame_vertices.push(Vertex::new([point.x, point.y], wall_color));
+            }
+            for i in 1..(ctx.visible_screen_polygon.count() as u16 - 1) {
+                ctx.frame_indices.push(start_vertex_index);
+                ctx.frame_indices.push(start_vertex_index + i);
+                ctx.frame_indices.push(start_vertex_index + i + 1);
+            }
+        }
+    }
+}
+
+pub struct StandardPortalHandler;
+impl SideHandler for StandardPortalHandler {
+    fn process_render(&self, ctx: &mut HandlerContext) {
+        let (target_instance_id_from_config, target_portal_id_on_target_bp_from_config) = match ctx.side_config {
+            HandlerConfig::StandardPortal { target_instance_id, target_portal_id } => (target_instance_id, target_portal_id),
+            _ => { return; } 
+        };
+        
+        let portal_local_normal = &ctx.blueprint_side.local_normal; // This is INWARD
+        let normal_in_host_bp_space = ctx.transform_to_camera_host_hull.transform_normal(portal_local_normal);
+        let normal_in_cam_space = ctx.camera_view_from_host_hull.transform_normal(&normal_in_host_bp_space);
+        
+        // Culling for INWARD NORMALS:
+        // Visible/Traversable if the inward normal (in view space) points generally along 
+        // the camera's view direction (AWAY from camera origin, so N_view.z > +epsilon).
+        // Camera looks down -Z.
+        let cull_threshold = 1e-3; 
+        if normal_in_cam_space.z <= cull_threshold { // If N_view.z is NOT > epsilon (i.e., points toward eye or is edge-on)
+            return; // CULL traversal
+        }
+        
+        if ctx.current_recursion_depth >= MAX_PORTAL_RECURSION_DEPTH { return; }
+        if !ctx.scene.instances.contains_key(target_instance_id_from_config) { return; }
+
+        let mut portal_alignment_transform = Mat4::identity();
+        let room_half_size = 1.5; 
+
+        match (ctx.blueprint_side.local_portal_id, *target_portal_id_on_target_bp_from_config) {
+            (Some(crate::demo_scene::PORTAL_ID_FRONT), crate::demo_scene::PORTAL_ID_BACK) => {
+                portal_alignment_transform = Mat4::from_translation(Point3::new(0.0, 0.0, room_half_size * 2.0));
+            }
+            (Some(crate::demo_scene::PORTAL_ID_BACK), crate::demo_scene::PORTAL_ID_FRONT) => {
+                portal_alignment_transform = Mat4::from_translation(Point3::new(0.0, 0.0, -room_half_size * 2.0));
+            }
+            (Some(crate::demo_scene::PORTAL_ID_RIGHT), crate::demo_scene::PORTAL_ID_LEFT) => {
+                portal_alignment_transform = Mat4::from_translation(Point3::new(room_half_size * 2.0, 0.0, 0.0));
+            }
+            (Some(crate::demo_scene::PORTAL_ID_LEFT), crate::demo_scene::PORTAL_ID_RIGHT) => {
+                portal_alignment_transform = Mat4::from_translation(Point3::new(-room_half_size * 2.0, 0.0, 0.0));
+            }
+            (Some(crate::demo_scene::PORTAL_ID_TOP), crate::demo_scene::PORTAL_ID_BOTTOM) => {
+                portal_alignment_transform = Mat4::from_translation(Point3::new(0.0, room_half_size * 2.0, 0.0));
+            }
+            (Some(crate::demo_scene::PORTAL_ID_BOTTOM), crate::demo_scene::PORTAL_ID_TOP) => {
+                portal_alignment_transform = Mat4::from_translation(Point3::new(0.0, -room_half_size * 2.0, 0.0));
+            }
+            _ => { /* Default to identity */ }
+        }
+        
+        let next_transform_to_camera_host_hull = ctx.transform_to_camera_host_hull.multiply(&portal_alignment_transform);
+        
+        ctx.traversal_queue.push_back(TraversalState {
+            current_instance_id: *target_instance_id_from_config,
+            accumulated_transform: next_transform_to_camera_host_hull,
+            screen_space_clip_polygon: ctx.visible_screen_polygon.clone(),
+            recursion_depth: ctx.current_recursion_depth + 1,
+        });
+    }
+}

--- a/src/rendering_lib/mod.rs
+++ b/src/rendering_lib/mod.rs
@@ -1,13 +1,14 @@
-// rendering_lib/src/lib.rs
+// src/rendering_lib/mod.rs
+
 pub mod renderer;
 pub mod shader;
 pub mod vertex;
-pub mod geometry; // For 2D screen-space operations used in portal culling
-pub mod intersection; // For 2D screen-space operations used in portal culling
+pub mod geometry;
+pub mod intersection;
 
-// Re-export key types if desired for easier use by the engine/app
 pub use renderer::Renderer;
 pub use vertex::Vertex;
 pub use geometry::{Point2, ConvexPolygon, MAX_VERTICES};
 pub use intersection::ConvexIntersection;
 pub use shader::WGSL_SHADER_SOURCE;
+// MAX_PORTAL_RECURSION_DEPTH is now in engine_lib::side_handler, so no need to export from here.

--- a/src/rendering_lib/renderer.rs
+++ b/src/rendering_lib/renderer.rs
@@ -1,22 +1,25 @@
-// src/renderer.rs
+// src/rendering_lib/renderer.rs
 
 use wgpu;
 use std::collections::VecDeque;
+use std::sync::Arc;
 use bytemuck::{Pod, Zeroable};
 use wgpu::util::DeviceExt;
 
-// Updated imports to use local library modules and engine_lib types
-use super::vertex::Vertex; // From rendering_lib::vertex
-use super::geometry::{ConvexPolygon, Point2, MAX_VERTICES}; // From rendering_lib::geometry
-use super::intersection::ConvexIntersection; // From rendering_lib::intersection
+use super::vertex::Vertex;
+use super::geometry::{ConvexPolygon, Point2, MAX_VERTICES};
+use super::intersection::ConvexIntersection;
 
-// Assuming engine_lib is a sibling module in the same crate
-use crate::engine_lib::scene_types::{Scene, Point3, TraversalState};
+// Refined imports - types needed for direct use or struct fields in this file's logic
+use crate::engine_lib::scene_types::{
+    Scene, Point3, TraversalState, Mat4, SideHandlerTypeId, SideIndex
+};
 use crate::engine_lib::camera::Camera;
+use crate::engine_lib::side_handler::{SideHandler, StandardWallHandler, StandardPortalHandler, HandlerContext};
 
 
-const RENDERER_MAX_VERTICES: usize = MAX_VERTICES * 6 * 10;
-const RENDERER_MAX_INDICES: usize = (MAX_VERTICES.saturating_sub(2)) * 3 * 6 * 10;
+const RENDERER_MAX_VERTICES: usize = MAX_VERTICES * 6 * 20;
+const RENDERER_MAX_INDICES: usize = (MAX_VERTICES.saturating_sub(2)) * 3 * 6 * 20;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Pod, Zeroable)]
@@ -27,10 +30,6 @@ struct ScreenDimensionsUniform {
     _padding2: f32,
 }
 
-// Helper function for 3D near-plane clipping (Sutherland-Hodgman for one plane)
-// Assumes polygon vertices are in camera space.
-// Near plane is z_cam = -camera_znear.
-// A point (x,y,z) is "inside" (visible) if z < -camera_znear.
 fn clip_polygon_near_plane_3d(
     polygon_cam_space: &[Point3],
     camera_znear: f32,
@@ -38,66 +37,55 @@ fn clip_polygon_near_plane_3d(
     if polygon_cam_space.is_empty() {
         return Vec::new();
     }
+    let mut output_list = Vec::with_capacity(polygon_cam_space.len() + 1);
+    // Guard against panic if polygon_cam_space is empty after check, though is_empty() should cover.
+    if polygon_cam_space.is_empty() { 
+        return output_list; 
+    }
 
-    let mut output_list = Vec::with_capacity(polygon_cam_space.len() + 1); // Max one extra vertex
-    let mut s = polygon_cam_space[polygon_cam_space.len() - 1]; // Start with the last vertex
+    let mut s = polygon_cam_space[polygon_cam_space.len() - 1];
+    for p_idx in 0..polygon_cam_space.len() {
+        let p = &polygon_cam_space[p_idx];
+        let s_is_inside = s.z < (-camera_znear + 1e-6); 
+        let p_is_inside = p.z < (-camera_znear + 1e-6);
 
-    for p in polygon_cam_space.iter() {
-        let s_is_inside = s.z < -camera_znear;
-        let p_is_inside = p.z < -camera_znear;
-
-        if s_is_inside && p_is_inside { // Case 1: Both inside, output P
+        if s_is_inside && p_is_inside {
             output_list.push(*p);
-        } else if s_is_inside && !p_is_inside { // Case 2: S inside, P outside, output intersection
-            // Calculate intersection point I of edge SP with plane z = -znear
-            // I = S + t(P - S)
-            // I.z = S.z + t(P.z - S.z) = -camera_znear
-            // t = (-camera_znear - S.z) / (P.z - S.z)
-            if (p.z - s.z).abs() > 1e-6 { // Avoid division by zero if edge is parallel to plane
+        } else if s_is_inside && !p_is_inside { 
+            if (p.z - s.z).abs() > 1e-6 { 
                 let t = (-camera_znear - s.z) / (p.z - s.z);
-                if t >= 0.0 && t <= 1.0 { // Intersection is within the segment
+                if t >= 0.0 && t <= 1.0 { 
                     let ix = s.x + t * (p.x - s.x);
                     let iy = s.y + t * (p.y - s.y);
                     output_list.push(Point3::new(ix, iy, -camera_znear));
-                } else if t < 0.0 && p_is_inside { // s is outside, p is inside, handled in next case (SHOULDN'T HAPPEN with current S,P logic)
-                     //This can happen if the segment crosses the plane beyond S, but p is inside.
-                     //It implies an issue or that P should have been the start of an exiting segment.
-                } else if t > 1.0 && s_is_inside { // s is inside, p is outside, segment crosses beyond p
-                    // This should mean the point -camera_znear is not between s.z and p.z, but this is checked by t conditions.
                 }
-
-            } else if s_is_inside { // Edge is parallel to plane and inside (or on plane)
-                // No intersection to add from this edge crossing, P will be handled next
             }
-        } else if !s_is_inside && p_is_inside { // Case 3: S outside, P inside, output I then P
+        } else if !s_is_inside && p_is_inside { 
             if (p.z - s.z).abs() > 1e-6 {
                 let t = (-camera_znear - s.z) / (p.z - s.z);
-                 if t >= 0.0 && t <= 1.0 { // Intersection is within the segment
+                if t >= 0.0 && t <= 1.0 { 
                     let ix = s.x + t * (p.x - s.x);
                     let iy = s.y + t * (p.y - s.y);
                     output_list.push(Point3::new(ix, iy, -camera_znear));
                 }
             }
-            output_list.push(*p); // P is inside
+            output_list.push(*p);
         }
-        // Case 4: Both S and P are outside, output nothing
-
-        s = *p; // Advance S to P for the next edge
+        s = *p;
     }
     output_list
 }
-
 
 pub struct Renderer {
     render_pipeline: wgpu::RenderPipeline,
     vertex_buffer: wgpu::Buffer,
     index_buffer: wgpu::Buffer,
-    
     frame_vertices: Vec<Vertex>,
     frame_indices: Vec<u16>,
-
     screen_uniform_buffer: wgpu::Buffer,
     screen_bind_group: wgpu::BindGroup,
+    wall_handler: Arc<StandardWallHandler>,
+    portal_handler: Arc<StandardPortalHandler>,
 }
 
 impl Renderer {
@@ -148,12 +136,11 @@ impl Renderer {
             label: Some("screen_dimensions_bind_group"),
         });
 
-        let render_pipeline_layout =
-            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-                label: Some("Renderer Pipeline Layout"),
-                bind_group_layouts: &[&screen_bind_group_layout],
-                push_constant_ranges: &[],
-            });
+        let render_pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("Renderer Pipeline Layout"),
+            bind_group_layouts: &[&screen_bind_group_layout],
+            push_constant_ranges: &[],
+        });
 
         let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             label: Some("Renderer Pipeline"),
@@ -161,7 +148,7 @@ impl Renderer {
             vertex: wgpu::VertexState {
                 module: &shader_module,
                 entry_point: "vs_main",
-                buffers: &[Vertex::desc()], // Vertex comes from rendering_lib::vertex
+                buffers: &[Vertex::desc()],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader_module,
@@ -176,17 +163,13 @@ impl Renderer {
                 topology: wgpu::PrimitiveTopology::TriangleList,
                 strip_index_format: None,
                 front_face: wgpu::FrontFace::Ccw,
-                cull_mode: None,
+                cull_mode: None, // Rely on manual culling or portal logic
                 polygon_mode: wgpu::PolygonMode::Fill,
                 unclipped_depth: false,
                 conservative: false,
             },
             depth_stencil: None,
-            multisample: wgpu::MultisampleState {
-                count: 1,
-                mask: !0,
-                alpha_to_coverage_enabled: false,
-            },
+            multisample: wgpu::MultisampleState::default(),
             multiview: None,
         });
 
@@ -212,24 +195,8 @@ impl Renderer {
             frame_indices: Vec::with_capacity(RENDERER_MAX_INDICES),
             screen_uniform_buffer,
             screen_bind_group,
-        }
-    }
-
-    fn add_polygon_to_frame(
-        &mut self,
-        polygon_2d: &ConvexPolygon, // ConvexPolygon comes from rendering_lib::geometry
-        color: [f32; 4],
-    ) {
-        if polygon_2d.count() < 3 { return; }
-        let start_vertex_index = self.frame_vertices.len() as u16;
-        for point in polygon_2d.vertices() {
-            // Vertex comes from rendering_lib::vertex, Point2 from rendering_lib::geometry
-            self.frame_vertices.push(Vertex::new([point.x, point.y], color));
-        }
-        for i in 1..(polygon_2d.count() as u16 - 1) {
-            self.frame_indices.push(start_vertex_index);
-            self.frame_indices.push(start_vertex_index + i);
-            self.frame_indices.push(start_vertex_index + i + 1);
+            wall_handler: Arc::new(StandardWallHandler),
+            portal_handler: Arc::new(StandardPortalHandler),
         }
     }
 
@@ -239,8 +206,8 @@ impl Renderer {
         queue: &wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
         output_view: &wgpu::TextureView,
-        scene: &Scene, // Scene comes from engine_lib::scene_types
-        camera: &Camera, // Camera comes from engine_lib::camera
+        scene: &Scene,
+        camera: &Camera,
         screen_width: f32,
         screen_height: f32,
         clear_color: wgpu::Color,
@@ -256,105 +223,30 @@ impl Renderer {
         self.frame_vertices.clear();
         self.frame_indices.clear();
 
-        let mut traversal_queue: VecDeque<TraversalState> = VecDeque::new(); // TraversalState from engine_lib::scene_types
+        let mut traversal_queue: VecDeque<TraversalState> = VecDeque::new();
+        let mut temp_traversal_queue_for_next_depth: VecDeque<TraversalState> = VecDeque::new();
+
         let initial_clip_points = [
-            Point2::new(0.0, 0.0), Point2::new(screen_width, 0.0), // Point2 from rendering_lib::geometry
-            Point2::new(screen_width, screen_height), Point2::new(0.0, screen_height),
+            Point2::new(0.0, 0.0),
+            Point2::new(screen_width, 0.0),
+            Point2::new(screen_width, screen_height),
+            Point2::new(0.0, screen_height),
         ];
-        // ConvexPolygon from rendering_lib::geometry
-        let initial_clip_polygon = ConvexPolygon::from_points(&initial_clip_points);
-        let start_hull_id = 0;
-
-        if !scene.hulls.is_empty() {
-             traversal_queue.push_back(TraversalState {
-                hull_id: start_hull_id, screen_space_clip_polygon: initial_clip_polygon,
-            });
-        }
-        let mut processed_hulls_this_frame: std::collections::HashSet<usize> = std::collections::HashSet::new();
+        let initial_screen_clip_polygon = ConvexPolygon::from_points(&initial_clip_points);
         
-        while let Some(current_state) = traversal_queue.pop_front() {
-            if processed_hulls_this_frame.contains(&current_state.hull_id) && traversal_queue.len() > scene.hulls.len() * 2 { continue; }
-            processed_hulls_this_frame.insert(current_state.hull_id);
+        let camera_view_from_host_hull = camera.get_view_matrix_from_host_hull(&scene.active_camera_local_transform);
 
-            let current_hull = match scene.hulls.get(current_state.hull_id) { Some(h) => h, None => continue };
-            let v_current = &current_state.screen_space_clip_polygon;
-
-            for side in &current_hull.sides {
-                if side.vertices_3d.is_empty() { continue; }
-                let point_on_side = side.vertices_3d[0]; // Point3 from engine_lib::scene_types
-                let cam_to_side_vec = point_on_side.sub(&camera.position);
-                if cam_to_side_vec.dot(&side.normal) <= 1e-3 { continue; }
-
-                // 1. Transform side vertices to camera space
-                let mut vertices_cam_space: Vec<Point3> = Vec::with_capacity(side.vertices_3d.len());
-                for v_world in &side.vertices_3d {
-                    vertices_cam_space.push(camera.transform_to_camera_space(v_world));
-                }
-
-                // 2. Clip polygon against near plane in camera space
-                // Point3 from engine_lib::scene_types
-                let clipped_vertices_cam_space = clip_polygon_near_plane_3d(&vertices_cam_space, camera.znear);
-
-                if clipped_vertices_cam_space.len() < 3 { continue; }
-
-                // 3. Project clipped camera-space vertices to 2D screen space
-                let mut projected_points_2d: Vec<Point2> = Vec::with_capacity(clipped_vertices_cam_space.len());
-                // Point2 from rendering_lib::geometry
-                for p_cam in &clipped_vertices_cam_space {
-                    if let Some(p2d) = camera.project_camera_space_to_screen(p_cam, screen_width, screen_height) {
-                        projected_points_2d.push(p2d);
-                    } else {
-                        // This case should ideally not happen
-                    }
-                }
-                
-                if projected_points_2d.len() < 3 { continue; }
-                
-                // ConvexPolygon from rendering_lib::geometry
-                let p_projected_clipped = ConvexPolygon::from_points(&projected_points_2d);
-                if p_projected_clipped.count() < 3 { continue; }
-
-                // 4. Proceed with 2D screen-space portal/wall logic
-                if side.is_portal {
-                    if let Some(next_hull_id) = side.connected_hull_id {
-                        let mut v_next = ConvexPolygon::new(); // ConvexPolygon from rendering_lib::geometry
-                        // ConvexIntersection from rendering_lib::intersection
-                        ConvexIntersection::find_intersection_into(v_current, &p_projected_clipped, &mut v_next);
-                        if v_next.count() >= 3 {
-                            if !processed_hulls_this_frame.contains(&next_hull_id) || !traversal_queue.iter().any(|s| s.hull_id == next_hull_id && s.screen_space_clip_polygon.vertices() == v_next.vertices()){
-                                traversal_queue.push_back(TraversalState { // TraversalState from engine_lib::scene_types
-                                    hull_id: next_hull_id, screen_space_clip_polygon: v_next,
-                                });
-                            }
-                        }
-                    }
-                } else {
-                    let mut final_clipped_wall_poly = ConvexPolygon::new(); // ConvexPolygon from rendering_lib::geometry
-                    // ConvexIntersection from rendering_lib::intersection
-                    ConvexIntersection::find_intersection_into(&p_projected_clipped, v_current, &mut final_clipped_wall_poly);
-                    if final_clipped_wall_poly.count() >= 3 {
-                        self.add_polygon_to_frame(&final_clipped_wall_poly, side.color);
-                    }
-                }
-            }
-        }
-
-        if !self.frame_vertices.is_empty() && !self.frame_indices.is_empty() {
-             if (self.frame_vertices.len() * std::mem::size_of::<Vertex>()) as u64 > self.vertex_buffer.size() ||
-               (self.frame_indices.len() * std::mem::size_of::<u16>()) as u64 > self.index_buffer.size() {
-                eprintln!("Renderer Warning: Frame data exceeds pre-allocated buffer capacity.");
-            }
-            
-            queue.write_buffer(&self.vertex_buffer, 0, bytemuck::cast_slice(&self.frame_vertices));
-            let mut padded_indices_data = self.frame_indices.clone();
-            // Ensure data is u8 aligned for webgl
-            if padded_indices_data.len() % 2 == 1 { padded_indices_data.push(0); } 
-            queue.write_buffer(&self.index_buffer, 0, bytemuck::cast_slice(&padded_indices_data));
-        }
-
-        {
-            let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                label: Some("Scene Render Pass (Renderer)"),
+        if scene.instances.contains_key(&scene.active_camera_instance_id) {
+            traversal_queue.push_back(TraversalState {
+                current_instance_id: scene.active_camera_instance_id,
+                accumulated_transform: Mat4::identity(),
+                screen_space_clip_polygon: initial_screen_clip_polygon,
+                recursion_depth: 0,
+            });
+        } else {
+            // Fallback clear if no valid start
+            let _render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Clear Pass (Error)"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                     view: output_view,
                     resolve_target: None,
@@ -362,26 +254,150 @@ impl Renderer {
                 })],
                 depth_stencil_attachment: None, occlusion_query_set: None, timestamp_writes: None,
             });
+            return;
+        }
+        
+        while let Some(current_traversal_state) = traversal_queue.pop_front() {
+            let current_instance = match scene.instances.get(&current_traversal_state.current_instance_id) {
+                Some(inst) => inst,
+                None => continue,
+            };
+            let blueprint = match scene.blueprints.get(&current_instance.blueprint_id) {
+                Some(bp) => bp,
+                None => continue,
+            };
 
-            if !self.frame_vertices.is_empty() && !self.frame_indices.is_empty() {
-                render_pass.set_pipeline(&self.render_pipeline);
-                render_pass.set_bind_group(0, &self.screen_bind_group, &[]);
+            for (side_idx, blueprint_side) in blueprint.sides.iter().enumerate() {
+                if blueprint_side.vertex_indices.len() < 3 {
+                    continue;
+                }
+
+                let mut side_vertices_bp_local: Vec<Point3> = Vec::with_capacity(blueprint_side.vertex_indices.len());
+                for &v_idx in &blueprint_side.vertex_indices {
+                    if v_idx < blueprint.local_vertices.len() {
+                        side_vertices_bp_local.push(blueprint.local_vertices[v_idx]);
+                    } else {
+                        side_vertices_bp_local.clear(); // Invalid state, skip this side
+                        break;
+                    }
+                }
+                if side_vertices_bp_local.len() < 3 {
+                    continue;
+                }
+
+                let transform_curr_bp_to_host_bp = &current_traversal_state.accumulated_transform;
+                let mut side_vertices_cam_space: Vec<Point3> = Vec::with_capacity(side_vertices_bp_local.len());
+                for p_bp_local in &side_vertices_bp_local {
+                    let p_host_hull_space = transform_curr_bp_to_host_bp.transform_point(p_bp_local);
+                    side_vertices_cam_space.push(camera_view_from_host_hull.transform_point(&p_host_hull_space));
+                }
+
+                let clipped_vertices_cam_space = clip_polygon_near_plane_3d(&side_vertices_cam_space, camera.znear);
+                if clipped_vertices_cam_space.len() < 3 {
+                    continue;
+                }
+
+                let mut projected_points_2d: Vec<Point2> = Vec::with_capacity(clipped_vertices_cam_space.len());
+                for p_cam in &clipped_vertices_cam_space {
+                    if let Some(p2d) = camera.project_camera_space_to_screen_direct(p_cam, screen_width, screen_height) {
+                        projected_points_2d.push(p2d);
+                    }
+                }
+                if projected_points_2d.len() < 3 {
+                    continue;
+                }
+
+                let p_projected_on_screen = ConvexPolygon::from_points(&projected_points_2d);
+                if p_projected_on_screen.count() < 3 {
+                    continue;
+                }
                 
-                let vertex_buffer_slice_size = (self.frame_vertices.len() * std::mem::size_of::<Vertex>()) as u64;
-                let effective_indices_count = self.frame_indices.len();
+                let mut final_visible_screen_polygon = ConvexPolygon::new();
+                ConvexIntersection::find_intersection_into(
+                    &p_projected_on_screen,
+                    &current_traversal_state.screen_space_clip_polygon,
+                    &mut final_visible_screen_polygon,
+                );
+                if final_visible_screen_polygon.count() < 3 {
+                    continue;
+                }
                 
-                // Calculate index buffer slice size correctly for potentially padded data
-                let index_buffer_slice_size = if self.frame_indices.len() % 2 == 1 {
-                    ((self.frame_indices.len() + 1) * std::mem::size_of::<u16>()) as u64
-                } else {
-                    (self.frame_indices.len() * std::mem::size_of::<u16>()) as u64
+                let side_config_override = current_instance.instance_side_handler_configs.get(&(side_idx as SideIndex));
+                let effective_config = side_config_override.unwrap_or(&blueprint_side.default_handler_config);
+                
+                let mut handler_ctx = HandlerContext {
+                    frame_vertices: &mut self.frame_vertices,
+                    frame_indices: &mut self.frame_indices,
+                    scene,
+                    camera,
+                    current_instance,
+                    blueprint_side,
+                    side_config: effective_config,
+                    transform_to_camera_host_hull: &current_traversal_state.accumulated_transform,
+                    camera_view_from_host_hull: &camera_view_from_host_hull,
+                    screen_width,
+                    screen_height,
+                    visible_screen_polygon: final_visible_screen_polygon,
+                    traversal_queue: &mut temp_traversal_queue_for_next_depth,
+                    current_recursion_depth: current_traversal_state.recursion_depth,
                 };
-
-
-                render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..vertex_buffer_slice_size));
-                render_pass.set_index_buffer(self.index_buffer.slice(..index_buffer_slice_size), wgpu::IndexFormat::Uint16);
-                render_pass.draw_indexed(0..effective_indices_count as u32, 0, 0..1);
+                
+                match effective_config.get_intended_handler_type() {
+                    SideHandlerTypeId::StandardWall => self.wall_handler.process_render(&mut handler_ctx),
+                    SideHandlerTypeId::StandardPortal => self.portal_handler.process_render(&mut handler_ctx),
+                    _ => { /* No-op for unhandled types */ }
+                }
             }
+            traversal_queue.append(&mut temp_traversal_queue_for_next_depth);
+        }
+        
+        if !self.frame_vertices.is_empty() && !self.frame_indices.is_empty() {
+            queue.write_buffer(&self.vertex_buffer, 0, bytemuck::cast_slice(&self.frame_vertices));
+            let mut padded_indices_data = self.frame_indices.clone();
+            if padded_indices_data.len() % 2 == 1 { 
+                padded_indices_data.push(0); // Align for WebGL
+            }
+            queue.write_buffer(&self.index_buffer, 0, bytemuck::cast_slice(&padded_indices_data));
+
+            let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Scene Render Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: output_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations { load: wgpu::LoadOp::Clear(clear_color), store: wgpu::StoreOp::Store },
+                })],
+                depth_stencil_attachment: None,
+                occlusion_query_set: None,
+                timestamp_writes: None,
+            });
+            render_pass.set_pipeline(&self.render_pipeline);
+            render_pass.set_bind_group(0, &self.screen_bind_group, &[]);
+            
+            let vertex_buffer_slice_size = (self.frame_vertices.len() * std::mem::size_of::<Vertex>()) as u64;
+            let effective_indices_count = self.frame_indices.len();
+            let index_buffer_slice_size = if self.frame_indices.len() % 2 == 1 {
+                ((self.frame_indices.len() + 1) * std::mem::size_of::<u16>()) as u64
+            } else {
+                (self.frame_indices.len() * std::mem::size_of::<u16>()) as u64
+            };
+
+            render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..vertex_buffer_slice_size));
+            render_pass.set_index_buffer(self.index_buffer.slice(..index_buffer_slice_size), wgpu::IndexFormat::Uint16);
+            render_pass.draw_indexed(0..effective_indices_count as u32, 0, 0..1);
+            
+        } else {
+            // If nothing to draw, still clear the screen
+            let _render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Clear Pass (Empty Scene)"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: output_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations { load: wgpu::LoadOp::Clear(clear_color), store: wgpu::StoreOp::Store },
+                })],
+                depth_stencil_attachment: None,
+                occlusion_query_set: None,
+                timestamp_writes: None,
+            });
         }
     }
 }


### PR DESCRIPTION
This pull request introduces a major refactoring of the scene representation and rendering pipeline to align with the advanced hull & portal system design outlined in docs/planning/blueprints.md. The primary goal is to move towards a more flexible, memory-efficient, and extensible engine capable of supporting complex spatial relationships and advanced rendering effects.

Key Architectural Changes:

Blueprint/Instance Model:

Introduced HullBlueprint for defining reusable hull geometry and default side properties in local blueprint space.
Introduced HullInstance to represent specific occurrences of blueprints, defining their connections and instance-specific configurations.
scene_types.rs has been significantly updated with these new data structures (HullBlueprint, BlueprintSide, HullInstance, PortalConnectionInfo, HandlerConfig, SideHandlerTypeId).
The demo_scene.rs has been completely rewritten to utilize this new model, including defining blueprint normals to point towards the interior of hulls.
Relativistic Hull-Space Rendering Pipeline (renderer.rs):

The rendering core now operates on a "relativistic hull-space" coordinate system. The camera's view is initially relative to its host hull instance.
A TraversalState struct manages the accumulated_transform (which brings subsequent hull blueprint spaces into the camera's host hull blueprint space) and the screen_space_clip_polygon for recursive portal rendering.
Side Handler System (engine_lib/side_handler.rs):

Abstracted side behaviors into a SideHandler trait.
Initial implementations for StandardWallHandler (renders an opaque, colored surface) and StandardPortalHandler have been added.
The renderer now dispatches rendering tasks to the appropriate handler based on the effective configuration of a hull side (blueprint default overridden by instance-specific config).
Core Logic Updates & Behavior Changes:

Portal Traversal and Alignment:

The StandardPortalHandler calculates a portal_alignment_transform to correctly position and orient a target hull's blueprint relative to the current hull's blueprint through their connected portal faces. For the current demo, this alignment for directly opposing faces (e.g., +Z to -Z) is primarily translational, assuming blueprints are pre-oriented for such connections.
The accumulated_transform is updated by concatenating these relative portal alignment transforms.
Portal Culling Based on Interior Normals:

As per specification, all blueprint side normals are defined to point towards the interior of their hollow hull.
The StandardPortalHandler now implements a back-face culling mechanism for portal traversal. A portal face is considered traversable if its interior normal, when transformed to camera view space, points generally along the camera's viewing direction (i.e., N_view.z > +epsilon for a camera looking down its local -Z axis).
This ensures that for a simple two-way doorway (e.g., Room 1's portal P1 connects to Room 2's portal P2, and P2 connects back to P1), looking from Room 1 through P1 shows Room 2. However, P2 (Room 2's side of the doorway) is correctly culled from further traversal from this viewpoint, preventing an unwanted recursive "hall of mirrors" effect for this basic scenario and matching the "office-kitchen" analogy.
Camera System (camera.rs, controller.rs):

The camera's pose (active_camera_local_transform in Scene) is now a Mat4 representing its position and orientation within its host HullInstance's blueprint space.
CameraController has been updated to modify this Mat4 pose directly, maintaining its own internal yaw/pitch state for smooth rotations and correct pitch clamping. User input for W/S movement and mouse pitch has been un-inverted.
The Camera struct primarily holds projection parameters, with get_view_matrix_from_host_hull() deriving the view matrix from the scene's camera pose.
Matrix Math (Mat4 in scene_types.rs):

Basic Mat4 operations (multiplication, point/normal transformation, inverse, constructors) have been implemented. (Note: These are foundational and should ideally be replaced with a dedicated linear algebra library for robustness and performance).
Outcome for Demo Scene:
The demo_scene.rs (with two rooms defined with portals that link back to each other) now correctly renders Room 1, and looking through its portal shows Room 2. The view into Room 2 correctly terminates at Room 2's walls (including the side that forms the doorway from Room 2's perspective, which is now correctly culled from further traversal from the initial viewpoint in Room 1). This matches the specified behavior for a simple open doorway between two interior spaces.