### PR TITLE
MovementFeature: Implement Camera Traversal Through Portals

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -9,7 +9,7 @@ use crate::rendering_lib::shader::WGSL_SHADER_SOURCE;
 use crate::rendering_lib::renderer::Renderer;
 use crate::engine_lib::camera::Camera;
 use crate::engine_lib::controller::CameraController;
-use crate::engine_lib::scene_types::Scene; // Mat4 removed from direct import
+use crate::engine_lib::scene_types::Scene;
 use crate::demo_scene;
 
 pub struct PolygonApp {
@@ -85,7 +85,6 @@ impl PolygonApp {
         );
 
         let scene = demo_scene::create_mvp_scene();
-
         let camera = Camera::new(75.0, 0.1, 100.0);
         
         let initial_focus = window.has_focus();
@@ -99,9 +98,8 @@ impl PolygonApp {
             } else { eprintln!("Could not grab cursor on init."); }
         }
         
-        // Initialize CameraController with the orientation from demo_scene's initial camera pose
-        let initial_cam_yaw_from_scene = std::f32::consts::PI; // Matches demo_scene
-        let initial_cam_pitch_from_scene = 0.0;             // Matches demo_scene
+        let initial_cam_yaw_from_scene = std::f32::consts::PI;
+        let initial_cam_pitch_from_scene = 0.0;
 
         let camera_controller = CameraController::new(
             initial_cam_yaw_from_scene, 
@@ -134,7 +132,8 @@ impl PolygonApp {
     }
 
     pub fn update(&mut self, dt: f32) {
-        self.camera_controller.apply_to_transform(&mut self.scene.active_camera_local_transform, dt);
+        // Pass &mut self.scene to apply_to_transform
+        self.camera_controller.apply_to_transform(&mut self.scene, dt);
     }
 
     pub fn render(&mut self, window: &Window) -> Result<(), wgpu::SurfaceError> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -85,8 +85,8 @@ impl PolygonApp {
         );
 
         let scene = demo_scene::create_mvp_scene();
-        let camera = Camera::new(75.0, 0.1, 100.0);
-        
+        let camera = Camera::new(75.0, 0.01, 100.0); // Changed znear from 0.1 to 0.01
+
         let initial_focus = window.has_focus();
         let mut initial_grab = false;
         if initial_focus {

--- a/src/engine_lib/mod.rs
+++ b/src/engine_lib/mod.rs
@@ -4,15 +4,17 @@ pub mod scene_types;
 pub mod camera;
 pub mod controller;
 pub mod side_handler;
+pub mod scene_logic; // Added new module
 
-// Re-export key types from the new structure
-// Point3 and Mat4 are no longer custom types from scene_types,
-// so they are not re-exported here. Consumers should use glam::Vec3 and glam::Mat4.
 pub use scene_types::{
     Scene, HullBlueprint, HullInstance, BlueprintSide,
-    HandlerConfig, SideHandlerTypeId, PortalConnectionInfo, TraversalState,
+    HandlerConfig, SideHandlerTypeId, PortalConnectionInfo, TraversalState, BoundaryCheckResult,
     InstanceId, BlueprintId, PortalId, SideIndex,
 };
 pub use camera::Camera;
 pub use controller::CameraController;
-pub use side_handler::{SideHandler, StandardWallHandler, StandardPortalHandler, HandlerContext, MAX_PORTAL_RECURSION_DEPTH};
+pub use side_handler::{
+    SideHandler, StandardWallHandler, StandardPortalHandler, HandlerContext,
+    MAX_PORTAL_RECURSION_DEPTH, get_portal_alignment_transform,
+};
+pub use scene_logic::{update_camera_in_scene, check_camera_hull_boundary}; // Re-export new functions

--- a/src/engine_lib/scene_logic.rs
+++ b/src/engine_lib/scene_logic.rs
@@ -1,0 +1,113 @@
+// src/engine_lib/scene_logic.rs
+use glam::{Mat4, Vec3, Vec4Swizzles}; // Added Vec4Swizzles
+use crate::engine_lib::scene_types::{
+    Scene, HullBlueprint, HullInstance, HandlerConfig,
+    SideIndex, BoundaryCheckResult, // Removed unused InstanceId, PortalId
+};
+use crate::engine_lib::side_handler::get_portal_alignment_transform;
+
+const COLLISION_EPSILON: f32 = 1e-4; // Small epsilon for plane distance
+
+pub fn check_camera_hull_boundary(
+    new_camera_pos_in_blueprint_space: &Vec3,
+    current_hull_blueprint: &HullBlueprint,
+    current_hull_instance: &HullInstance,
+) -> BoundaryCheckResult {
+    for (side_idx, blueprint_side) in current_hull_blueprint.sides.iter().enumerate() {
+        if blueprint_side.vertex_indices.is_empty() {
+            continue;
+        }
+        let point_on_plane = current_hull_blueprint.local_vertices[blueprint_side.vertex_indices[0]];
+        let normal = blueprint_side.local_normal;
+
+        let d_plane_constant = -normal.dot(point_on_plane);
+        let signed_distance = normal.dot(*new_camera_pos_in_blueprint_space) + d_plane_constant;
+
+        if signed_distance < -COLLISION_EPSILON {
+            let handler_config = current_hull_instance
+                .instance_side_handler_configs
+                .get(&(side_idx as SideIndex))
+                .unwrap_or(&blueprint_side.default_handler_config);
+
+            match handler_config {
+                HandlerConfig::StandardPortal { target_instance_id, target_portal_id } => {
+                    if blueprint_side.local_portal_id.is_some() {
+                         return BoundaryCheckResult::Traverse {
+                            crossed_side_index: side_idx as SideIndex,
+                            target_instance_id: *target_instance_id,
+                            target_portal_id: *target_portal_id,
+                        };
+                    } else {
+                        return BoundaryCheckResult::Collision {
+                            collided_side_index: side_idx as SideIndex,
+                            collision_point: *new_camera_pos_in_blueprint_space,
+                        };
+                    }
+                }
+                _ => {
+                    return BoundaryCheckResult::Collision {
+                        collided_side_index: side_idx as SideIndex,
+                        collision_point: *new_camera_pos_in_blueprint_space,
+                    };
+                }
+            }
+        }
+    }
+    BoundaryCheckResult::Inside
+}
+
+pub fn update_camera_in_scene(
+    scene: &mut Scene,
+    potential_new_local_pos: Vec3,
+    new_rotation_matrix: Mat4,
+    _dt: f32,
+) {
+    let current_instance_id = scene.active_camera_instance_id;
+
+    let (blueprint_id, _initial_transform_needed_for_bp_lookup) = { // Renamed variable to avoid unused warning
+        let instance = scene.instances.get(&current_instance_id)
+            .expect("Active camera instance not found in scene.");
+        (instance.blueprint_id, instance.initial_transform)
+    };
+    let current_hull_blueprint = scene.blueprints.get(&blueprint_id)
+        .expect("Blueprint for active camera instance not found.").clone();
+    
+    let current_hull_instance_clone = scene.instances.get(&current_instance_id)
+         .expect("Active camera instance not found for clone.")
+         .clone();
+
+
+    let boundary_check_result = check_camera_hull_boundary(
+        &potential_new_local_pos,
+        &current_hull_blueprint,
+        &current_hull_instance_clone,
+    );
+
+    match boundary_check_result {
+        BoundaryCheckResult::Inside => {
+            scene.active_camera_local_transform = Mat4::from_translation(potential_new_local_pos) * new_rotation_matrix;
+        }
+        BoundaryCheckResult::Collision { collided_side_index: _, collision_point: _ } => {
+            let old_position = scene.active_camera_local_transform.w_axis.xyz(); // This line should now work
+            scene.active_camera_local_transform = Mat4::from_translation(old_position) * new_rotation_matrix;
+        }
+        BoundaryCheckResult::Traverse { crossed_side_index, target_instance_id, target_portal_id } => {
+            let source_portal_id_on_current_bp = current_hull_blueprint.sides[crossed_side_index]
+                .local_portal_id
+                .expect("Traversal initiated but source blueprint side has no local_portal_id.");
+
+            let portal_alignment_transform_target_to_current = get_portal_alignment_transform(
+                source_portal_id_on_current_bp,
+                target_portal_id,
+            );
+
+            let camera_pose_if_crossed_in_old_bp = Mat4::from_translation(potential_new_local_pos) * new_rotation_matrix;
+            let new_camera_pose_in_new_bp = portal_alignment_transform_target_to_current.inverse() * camera_pose_if_crossed_in_old_bp;
+
+            scene.active_camera_instance_id = target_instance_id;
+            scene.active_camera_local_transform = new_camera_pose_in_new_bp;
+
+            // TODO: Adjust CameraController's current_yaw/current_pitch if portal_alignment_transform involved rotation.
+        }
+    }
+}

--- a/src/engine_lib/scene_logic.rs
+++ b/src/engine_lib/scene_logic.rs
@@ -63,35 +63,83 @@ pub fn update_camera_in_scene(
     _dt: f32,
 ) {
     let current_instance_id = scene.active_camera_instance_id;
-
-    let (blueprint_id, _initial_transform_needed_for_bp_lookup) = { // Renamed variable to avoid unused warning
-        let instance = scene.instances.get(&current_instance_id)
-            .expect("Active camera instance not found in scene.");
-        (instance.blueprint_id, instance.initial_transform)
-    };
-    let current_hull_blueprint = scene.blueprints.get(&blueprint_id)
-        .expect("Blueprint for active camera instance not found.").clone();
-    
-    let current_hull_instance_clone = scene.instances.get(&current_instance_id)
+    let current_instance_clone = scene.instances.get(&current_instance_id)
          .expect("Active camera instance not found for clone.")
          .clone();
-
+    let current_hull_blueprint = scene.blueprints.get(&current_instance_clone.blueprint_id)
+        .expect("Blueprint for active camera instance not found.").clone();
 
     let boundary_check_result = check_camera_hull_boundary(
         &potential_new_local_pos,
         &current_hull_blueprint,
-        &current_hull_instance_clone,
+        &current_instance_clone,
     );
 
     match boundary_check_result {
         BoundaryCheckResult::Inside => {
             scene.active_camera_local_transform = Mat4::from_translation(potential_new_local_pos) * new_rotation_matrix;
         }
-        BoundaryCheckResult::Collision { collided_side_index: _, collision_point: _ } => {
-            let old_position = scene.active_camera_local_transform.w_axis.xyz(); // This line should now work
-            scene.active_camera_local_transform = Mat4::from_translation(old_position) * new_rotation_matrix;
+        BoundaryCheckResult::Collision { collided_side_index, collision_point: _ } => { // collision_point is potential_new_local_pos
+            let old_position = scene.active_camera_local_transform.w_axis.xyz();
+            
+            // --- Implement Push Out ---
+            let collided_side_normal = current_hull_blueprint.sides[collided_side_index].local_normal;
+            
+            // We want to move the potential_new_local_pos back along the collided_side_normal
+            // so that its distance to the plane is a small positive value (e.g., PUSH_OUT_DISTANCE).
+            // Original signed distance for potential_new_local_pos was < -COLLISION_EPSILON.
+            // Let current signed_distance = normal.dot(potential_new_local_pos) + d_plane_constant
+            // We want new_signed_distance = PUSH_OUT_DISTANCE.
+            // The change in position is along 'collided_side_normal'.
+            // Let new_pos = potential_new_local_pos + k * collided_side_normal.
+            // normal.dot(potential_new_local_pos + k * collided_side_normal) + d_plane_constant = PUSH_OUT_DISTANCE
+            // normal.dot(potential_new_local_pos) + d_plane_constant + k * normal.dot(collided_side_normal) = PUSH_OUT_DISTANCE
+            // signed_distance + k * (normal.length_squared()) = PUSH_OUT_DISTANCE
+            // k = (PUSH_OUT_DISTANCE - signed_distance) / normal.length_squared()
+
+            // Let's recalculate signed_distance for clarity here, or pass it from check_camera_hull_boundary
+            let point_on_plane = current_hull_blueprint.local_vertices[current_hull_blueprint.sides[collided_side_index].vertex_indices[0]];
+            let d_plane_constant = -collided_side_normal.dot(point_on_plane);
+            let signed_distance_at_potential_pos = collided_side_normal.dot(potential_new_local_pos) + d_plane_constant;
+
+            const PUSH_OUT_DISTANCE: f32 = 1e-3; // Small distance to be outside the plane
+
+            let mut corrected_position = potential_new_local_pos;
+            if collided_side_normal.length_squared() > 1e-6 { // Avoid division by zero if normal is zero
+                // We know signed_distance_at_potential_pos is negative (e.g. -0.001)
+                // We want it to be PUSH_OUT_DISTANCE (e.g. 0.001)
+                // k = (0.001 - (-0.001)) / len_sq = 0.002 / len_sq
+                let k = (PUSH_OUT_DISTANCE - signed_distance_at_potential_pos) / collided_side_normal.length_squared();
+                corrected_position = potential_new_local_pos + k * collided_side_normal;
+            } else {
+                // Normal is zero, unusual. Fallback to old position.
+                corrected_position = old_position;
+            }
+            
+            // Sanity check: ensure corrected_position is not further than old_position if movement was small
+            // This logic can get complex if multiple collisions happen or if k is very large.
+            // For now, a simple push: If the camera intended to move into a wall,
+            // place it just outside the wall, but allow rotation.
+            // A simpler push: just use the old_position for position component.
+            // The more precise push might be better though.
+
+            // Check if the corrected position is "better" than just staying at old_position.
+            // If the original movement was tiny, this push might overshoot.
+            // A simpler approach for now: just project potential_new_local_pos onto the plane and add a small offset.
+            // Projected_pos = P - (N.P + d) * N / N.length_squared()
+            // projected_on_plane = potential_new_local_pos - signed_distance_at_potential_pos * collided_side_normal / collided_side_normal.length_squared();
+            // corrected_position = projected_on_plane + PUSH_OUT_DISTANCE * collided_side_normal.normalize_or_zero();
+
+            // Sticking to the k-based correction for now:
+            scene.active_camera_local_transform = Mat4::from_translation(corrected_position) * new_rotation_matrix;
+            
+            // Fallback to simpler "just don't move position" if push-out is problematic:
+            // scene.active_camera_local_transform = Mat4::from_translation(old_position) * new_rotation_matrix;
         }
         BoundaryCheckResult::Traverse { crossed_side_index, target_instance_id, target_portal_id } => {
+            // ... (existing traversal logic) ...
+            // Consider adding a PUSH_OUT_DISTANCE equivalent for portal traversal too,
+            // to ensure the camera starts slightly *inside* the new room, not exactly on the plane.
             let source_portal_id_on_current_bp = current_hull_blueprint.sides[crossed_side_index]
                 .local_portal_id
                 .expect("Traversal initiated but source blueprint side has no local_portal_id.");
@@ -102,12 +150,27 @@ pub fn update_camera_in_scene(
             );
 
             let camera_pose_if_crossed_in_old_bp = Mat4::from_translation(potential_new_local_pos) * new_rotation_matrix;
-            let new_camera_pose_in_new_bp = portal_alignment_transform_target_to_current.inverse() * camera_pose_if_crossed_in_old_bp;
+            let mut new_camera_pose_in_new_bp = portal_alignment_transform_target_to_current.inverse() * camera_pose_if_crossed_in_old_bp;
+
+            // --- Experimental push into new room ---
+            // The "forward" direction for the camera in its new local space is -Z.
+            // We want to push it slightly along its new local -Z axis.
+            const TRAVERSAL_PUSH_DISTANCE: f32 = 1e-3; // Small push
+            let local_push_vec = Vec3::new(0.0, 0.0, -TRAVERSAL_PUSH_DISTANCE); // Along local -Z
+            
+            // Extract rotation and translation from the new pose
+            let (scale, rot_quat, trans) = new_camera_pose_in_new_bp.to_scale_rotation_translation();
+            let rotation_matrix_of_new_pose = Mat4::from_quat(rot_quat); // Assuming uniform scale Mat4::from_rotation_translation also works
+            
+            let world_ish_push_offset = rotation_matrix_of_new_pose.transform_vector3(local_push_vec);
+            let pushed_translation = trans + world_ish_push_offset;
+            
+            new_camera_pose_in_new_bp = Mat4::from_scale_rotation_translation(scale, rot_quat, pushed_translation);
+            // --- End experimental push ---
+
 
             scene.active_camera_instance_id = target_instance_id;
             scene.active_camera_local_transform = new_camera_pose_in_new_bp;
-
-            // TODO: Adjust CameraController's current_yaw/current_pitch if portal_alignment_transform involved rotation.
         }
     }
 }

--- a/src/engine_lib/scene_types.rs
+++ b/src/engine_lib/scene_types.rs
@@ -1,6 +1,5 @@
 // src/engine_lib/scene_types.rs
-
-use glam::{Mat4, Vec3}; // Changed
+use glam::{Mat4, Vec3};
 use crate::rendering_lib::geometry::ConvexPolygon;
 
 // Type aliases for IDs
@@ -8,9 +7,6 @@ pub type BlueprintId = u32;
 pub type InstanceId = u32;
 pub type PortalId = u32;
 pub type SideIndex = usize;
-
-// Mat4 and Point3 structs and their impl blocks have been removed.
-// glam::Mat4 and glam::Vec3 will be used directly.
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum SideHandlerTypeId {
@@ -42,7 +38,7 @@ impl HandlerConfig {
             HandlerConfig::CameraDisplay { .. } => SideHandlerTypeId::CameraDisplay,
             HandlerConfig::NonEuclideanPortal { .. } => SideHandlerTypeId::NonEuclideanPortal,
             HandlerConfig::TransparentWall { .. } => SideHandlerTypeId::TransparentWall,
-            HandlerConfig::None => SideHandlerTypeId::StandardWall,
+            HandlerConfig::None => SideHandlerTypeId::StandardWall, // Default to wall if None
         }
     }
 }
@@ -50,7 +46,7 @@ impl HandlerConfig {
 #[derive(Clone, Debug)]
 pub struct BlueprintSide {
     pub vertex_indices: Vec<usize>,
-    pub local_normal: Vec3, // Changed from Point3
+    pub local_normal: Vec3,
     pub handler_type: SideHandlerTypeId,
     pub default_handler_config: HandlerConfig,
     pub local_portal_id: Option<PortalId>,
@@ -60,7 +56,7 @@ pub struct BlueprintSide {
 pub struct HullBlueprint {
     pub id: BlueprintId,
     pub name: String,
-    pub local_vertices: Vec<Vec3>, // Changed from Point3
+    pub local_vertices: Vec<Vec3>,
     pub sides: Vec<BlueprintSide>,
 }
 
@@ -75,7 +71,7 @@ pub struct HullInstance {
     pub id: InstanceId,
     pub name: String,
     pub blueprint_id: BlueprintId,
-    pub initial_transform: Option<Mat4>, // Uses glam::Mat4
+    pub initial_transform: Option<Mat4>,
     pub portal_connections: std::collections::HashMap<PortalId, PortalConnectionInfo>,
     pub instance_side_handler_configs: std::collections::HashMap<SideIndex, HandlerConfig>,
 }
@@ -85,13 +81,28 @@ pub struct Scene {
     pub blueprints: std::collections::HashMap<BlueprintId, HullBlueprint>,
     pub instances: std::collections::HashMap<InstanceId, HullInstance>,
     pub active_camera_instance_id: InstanceId,
-    pub active_camera_local_transform: Mat4, // Uses glam::Mat4
+    pub active_camera_local_transform: Mat4,
 }
 
 #[derive(Clone)]
 pub struct TraversalState {
     pub current_instance_id: InstanceId,
-    pub accumulated_transform: Mat4, // Uses glam::Mat4
+    pub accumulated_transform: Mat4,
     pub screen_space_clip_polygon: ConvexPolygon,
     pub recursion_depth: u32,
+}
+
+// ADDED BoundaryCheckResult Enum
+#[derive(Debug, Clone, PartialEq)]
+pub enum BoundaryCheckResult {
+    Inside,
+    Collision {
+        collided_side_index: SideIndex,
+        collision_point: Vec3,
+    },
+    Traverse {
+        crossed_side_index: SideIndex,
+        target_instance_id: InstanceId,
+        target_portal_id: PortalId,
+    },
 }

--- a/src/engine_lib/side_handler.rs
+++ b/src/engine_lib/side_handler.rs
@@ -1,15 +1,18 @@
 // src/engine_lib/side_handler.rs
 use std::collections::VecDeque;
-use glam::{Mat4, Vec3}; // Changed
+use glam::{Mat4, Vec3};
 use crate::engine_lib::scene_types::{
     Scene, HandlerConfig,
-    HullInstance, BlueprintSide, TraversalState
-    // SideHandlerTypeId is inferred from HandlerConfig::get_intended_handler_type()
-    // HullBlueprint is accessed via scene.blueprints
+    HullInstance, BlueprintSide, TraversalState, PortalId,
 };
 use crate::engine_lib::camera::Camera;
 use crate::rendering_lib::geometry::ConvexPolygon;
 use crate::rendering_lib::vertex::Vertex;
+// Use public demo_scene constants
+use crate::demo_scene::{
+    PORTAL_ID_FRONT, PORTAL_ID_BACK, PORTAL_ID_LEFT, PORTAL_ID_RIGHT, PORTAL_ID_TOP, PORTAL_ID_BOTTOM,
+};
+
 
 pub const MAX_PORTAL_RECURSION_DEPTH: u32 = 10;
 
@@ -21,8 +24,8 @@ pub struct HandlerContext<'a> {
     pub current_instance: &'a HullInstance,
     pub blueprint_side: &'a BlueprintSide,
     pub side_config: &'a HandlerConfig,
-    pub transform_to_camera_host_hull: &'a Mat4, // Uses glam::Mat4
-    pub camera_view_from_host_hull: &'a Mat4,   // Uses glam::Mat4
+    pub transform_to_camera_host_hull: &'a Mat4,
+    pub camera_view_from_host_hull: &'a Mat4,
     pub screen_width: f32,
     pub screen_height: f32,
     pub visible_screen_polygon: ConvexPolygon,
@@ -55,6 +58,39 @@ impl SideHandler for StandardWallHandler {
     }
 }
 
+// ADDED this function
+pub fn get_portal_alignment_transform(
+    source_portal_id_on_current_bp: PortalId,
+    target_portal_id_on_target_bp: PortalId,
+) -> Mat4 {
+    let room_half_size = 1.5; // Matches demo_scene.rs cuboid half_size
+
+    match (source_portal_id_on_current_bp, target_portal_id_on_target_bp) {
+        (PORTAL_ID_FRONT, PORTAL_ID_BACK) => {
+            Mat4::from_translation(Vec3::new(0.0, 0.0, room_half_size * 2.0))
+        }
+        (PORTAL_ID_BACK, PORTAL_ID_FRONT) => {
+            Mat4::from_translation(Vec3::new(0.0, 0.0, -room_half_size * 2.0))
+        }
+        (PORTAL_ID_RIGHT, PORTAL_ID_LEFT) => {
+            Mat4::from_translation(Vec3::new(room_half_size * 2.0, 0.0, 0.0))
+        }
+        (PORTAL_ID_LEFT, PORTAL_ID_RIGHT) => {
+            Mat4::from_translation(Vec3::new(-room_half_size * 2.0, 0.0, 0.0))
+        }
+        (PORTAL_ID_TOP, PORTAL_ID_BOTTOM) => {
+            Mat4::from_translation(Vec3::new(0.0, room_half_size * 2.0, 0.0))
+        }
+        (PORTAL_ID_BOTTOM, PORTAL_ID_TOP) => {
+            Mat4::from_translation(Vec3::new(0.0, -room_half_size * 2.0, 0.0))
+        }
+        _ => {
+            Mat4::IDENTITY
+        }
+    }
+}
+
+
 pub struct StandardPortalHandler;
 impl SideHandler for StandardPortalHandler {
     fn process_render(&self, ctx: &mut HandlerContext) {
@@ -63,11 +99,8 @@ impl SideHandler for StandardPortalHandler {
             _ => { return; }
         };
 
-        let portal_local_normal: &Vec3 = &ctx.blueprint_side.local_normal; // Changed to Vec3
+        let portal_local_normal: &Vec3 = &ctx.blueprint_side.local_normal;
         
-        // For normals (directions), transform with w=0 and normalize.
-        // The upper 3x3 of the matrix is used. If non-uniform scaling, inverse transpose is needed.
-        // Assuming rotation/uniform scale for now, matching previous simplified logic.
         let normal_in_host_bp_space = ctx.transform_to_camera_host_hull.transform_vector3(*portal_local_normal).normalize_or_zero();
         let normal_in_cam_space = ctx.camera_view_from_host_hull.transform_vector3(normal_in_host_bp_space).normalize_or_zero();
 
@@ -79,32 +112,13 @@ impl SideHandler for StandardPortalHandler {
         if ctx.current_recursion_depth >= MAX_PORTAL_RECURSION_DEPTH { return; }
         if !ctx.scene.instances.contains_key(target_instance_id_from_config) { return; }
 
-        let mut portal_alignment_transform = Mat4::IDENTITY; // Changed
-        let room_half_size = 1.5;
-
-        match (ctx.blueprint_side.local_portal_id, *target_portal_id_on_target_bp_from_config) {
-            (Some(crate::demo_scene::PORTAL_ID_FRONT), crate::demo_scene::PORTAL_ID_BACK) => {
-                portal_alignment_transform = Mat4::from_translation(Vec3::new(0.0, 0.0, room_half_size * 2.0));
-            }
-            (Some(crate::demo_scene::PORTAL_ID_BACK), crate::demo_scene::PORTAL_ID_FRONT) => {
-                portal_alignment_transform = Mat4::from_translation(Vec3::new(0.0, 0.0, -room_half_size * 2.0));
-            }
-            (Some(crate::demo_scene::PORTAL_ID_RIGHT), crate::demo_scene::PORTAL_ID_LEFT) => {
-                portal_alignment_transform = Mat4::from_translation(Vec3::new(room_half_size * 2.0, 0.0, 0.0));
-            }
-            (Some(crate::demo_scene::PORTAL_ID_LEFT), crate::demo_scene::PORTAL_ID_RIGHT) => {
-                portal_alignment_transform = Mat4::from_translation(Vec3::new(-room_half_size * 2.0, 0.0, 0.0));
-            }
-            (Some(crate::demo_scene::PORTAL_ID_TOP), crate::demo_scene::PORTAL_ID_BOTTOM) => {
-                portal_alignment_transform = Mat4::from_translation(Vec3::new(0.0, room_half_size * 2.0, 0.0));
-            }
-            (Some(crate::demo_scene::PORTAL_ID_BOTTOM), crate::demo_scene::PORTAL_ID_TOP) => {
-                portal_alignment_transform = Mat4::from_translation(Vec3::new(0.0, -room_half_size * 2.0, 0.0));
-            }
-            _ => { /* Default to identity */ }
-        }
-
-        let next_transform_to_camera_host_hull = *ctx.transform_to_camera_host_hull * portal_alignment_transform; // Changed
+        // Use the new centralized function
+        let portal_alignment_transform = get_portal_alignment_transform(
+            ctx.blueprint_side.local_portal_id.expect("Portal handler on side with no local_portal_id"),
+            *target_portal_id_on_target_bp_from_config
+        );
+        
+        let next_transform_to_camera_host_hull = *ctx.transform_to_camera_host_hull * portal_alignment_transform;
 
         ctx.traversal_queue.push_back(TraversalState {
             current_instance_id: *target_instance_id_from_config,


### PR DESCRIPTION
**Related Document(s):**
* Roadmap: [Seamless Camera Traversal Through Portals](uploaded:guylsmith1972/engine3/Engine3-movement/docs/planning/pending/roadmap.md)
* Design Document: [Advanced Hull & Portal System](uploaded:guylsmith1972/engine3/Engine3-movement/docs/planning/completed/blueprints.md)
* Developer Guide: [Engine3 - Developer's Guide: Core Rendering Concepts](uploaded:guylsmith1972/engine3/Engine3-movement/docs/guides/developer_guide.md)

**Changes Proposed:**

This pull request implements the "Seamless Camera Traversal Through Portals" feature outlined in the project roadmap. The primary goal was to allow the player's camera to physically transition from one hull instance into another when moving through a connecting portal.

**Key Implementation Details:**

1.  **Boundary Checking Logic (`scene_logic.rs`):**
    * A new module `scene_logic.rs` has been introduced within `engine_lib`.
    * The `check_camera_hull_boundary` function determines if the camera's potential new position is inside its current hull, colliding with a solid boundary, or attempting to traverse a portal.
        * It iterates through the sides of the current hull's blueprint.
        * For each side, it calculates the signed distance from the camera's potential position to the plane of the side. Normals point inward, so a negative distance indicates the camera is outside that specific side.
        * A `BoundaryCheckResult` enum (`Inside`, `Collision`, `Traverse`) is returned.
    * The `update_camera_in_scene` function uses this result to update the scene state.

2.  **Camera Controller Update (`controller.rs`):**
    * The `CameraController::apply_to_transform` method now delegates movement updates to `scene_logic::update_camera_in_scene`.
    * It calculates the potential new local position and new rotation matrix, then calls the scene logic to handle boundary checks and state updates.

3.  **Portal Traversal Mechanism:**
    * When `BoundaryCheckResult::Traverse` is determined:
        * The `portal_alignment_transform` (transforming the target blueprint space to the current blueprint space) is retrieved using a centralized function `get_portal_alignment_transform` (added to `side_handler.rs`). This function currently uses the demo scene's specific translational logic.
        * The camera's pose (which would have just crossed the portal) in the old hull's blueprint space is transformed by the *inverse* of the `portal_alignment_transform`. This correctly calculates the camera's new local pose relative to the *new* hull's blueprint space.
        * The `scene.active_camera_instance_id` is updated to the target instance ID.
        * The `scene.active_camera_local_transform` is updated with the new pose.

4.  **Collision Handling (Basic):**
    * If `BoundaryCheckResult::Collision` occurs (i.e., the camera attempts to move through a non-portal side):
        * The camera's positional update is currently modified by a "push-out" mechanism to place it slightly away from the collided plane, preventing interpenetration based on `COLLISION_EPSILON`. Rotational updates are still applied. (Note: The effectiveness of the push-out for all visual artifacts is a separate ongoing concern.)

5.  **Portal Culling Logic Update (Experimentation):**
    * The culling logic within `StandardPortalHandler` was changed from checking `normal_in_cam_space.z` to a method based on the plane equation constant `D_plane = - (normal_in_cam_space · P0_cam_space)`, culling if `D_plane` is negative (i.e., culling if `normal_in_cam_space · P0_cam_space > 0`). This was an attempt to address some observed clipping issues.

**How to Test:**

1.  Run the application (`cargo run`).
2.  Navigate the camera towards the portal connecting the two rooms in the demo scene.
3.  The camera should seamlessly transition from Room 1 to Room 2, and vice-versa. The controls should remain consistent relative to the camera's new orientation within the new hull.
4.  Test movement against opaque walls. The camera should collide and stop or be pushed out slightly, rather than passing through.

**Future Considerations (Out of Scope for this PR):**
* Further investigation and refinement of near-plane clipping behavior when the camera is extremely close to surfaces.
* Adjusting the `CameraController`'s internal yaw/pitch if a portal traversal involves rotational alignment to maintain world-space view consistency. The current demo portals are translational only.
* Generalizing the `get_portal_alignment_transform` function beyond the demo scene's hardcoded cuboid alignments.

This implementation successfully enables the camera to move between different hull instances according to the portal definitions, updating its reference frame as it traverses.